### PR TITLE
(MAINT) Remove archived dependency

### DIFF
--- a/pubcontrolclient.go
+++ b/pubcontrolclient.go
@@ -11,7 +11,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"io/ioutil"
 	"net/http"
 	"strconv"


### PR DESCRIPTION
**What**
Update the `github.com/dgrijalva/jwt-go` dependency to be `github.com/golang-jwt/jwt`

**Why**
[`github.com/dgrijalva/jwt-go`](https://github.com/dgrijalva/jwt-go) has been archived and moved to a maintained repo here https://github.com/golang-jwt/jwt . 
See https://github.com/dgrijalva/jwt-go#this-repository-is-no-longer-maintaned for more info. 

This indirect dependency was raised as a security issue as part of an ongoing exercise to open source a private repository.